### PR TITLE
chore: remove replace directive for go install

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -14,8 +13,7 @@ import (
 	"strings"
 	"unicode"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/gedex/inflector"
 	"github.com/idubinskiy/schematyper/stringset"
 )
@@ -612,7 +610,7 @@ func parseDefs(s *metaSchema, path string) {
 func main() {
 	kingpin.Parse()
 
-	file, err := ioutil.ReadFile(*inputFile)
+	file, err := os.ReadFile(*inputFile)
 	if err != nil {
 		log.Fatalln("Error reading file:", err)
 	}
@@ -663,7 +661,7 @@ func main() {
 			compactSchemaName := strings.ToLower(*rootTypeName)
 			outputFileName = fmt.Sprintf("%s_schematype.go", compactSchemaName)
 		}
-		err = ioutil.WriteFile(outputFileName, formattedSrc, 0644)
+		err = os.WriteFile(outputFileName, formattedSrc, 0o644)
 		if err != nil {
 			log.Fatalf("Error writing to %s: %s\n", outputFileName, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/awa/schematyper
 go 1.23.3
 
 require (
+	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813
 	github.com/idubinskiy/schematyper v0.0.0-20190118213059-f71b40dac30d
 	github.com/smartystreets/goconvey v1.8.1
-	gopkg.in/alecthomas/kingpin.v2 v2.4.0
 )
 
 require (
@@ -16,5 +16,3 @@ require (
 	github.com/smarty/assertions v1.15.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 )
-
-replace gopkg.in/alecthomas/kingpin.v2 v2.4.0 => github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
## Summary

- go install を実行するとき replace directive があるとエラー

```
"The go.mod file for the module providing named packages contains one or more replace directives. It must not contain directives that would cause it to be interpreted differently than if it were the main module".
```

## Issue

- https://github.com/awa/awa-payment-server/issues/1818